### PR TITLE
feat: add web demo interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,36 @@
+# PochiPochi Composer
+
+SRSに基づくMVP実装です。子どもが選んだタグから音楽属性を決定し、安全なミックスとスケール補正を行うユーティリティを提供します。
+
+## 概要
+
+- `mapTagsToAttributes(tags, tempo?, key?)`
+  - 最大3つのタグ（例: `ねこ`, `ねむい`, `だいぼうけん`）をBPM・楽器・ドラムパターン・ミックス設定に変換します。
+- `enforceKidSafeMix(mix)`
+  - 高域ブーストやラウドネスを子ども向けに制限します。
+- `quantizeAndClamp(melody, key, scale)`
+  - メロディを量子化し、スケール外音を最近傍音に吸着させます。
+
+## デモ
+
+`npm start` でブラウザ向け簡易デモを起動できます。
+
+## ディレクトリ構成
+
+- `src/prompt-mapper.js` – ユーティリティ本体
+- `public/` – Webインターフェース
+- `server.js` – 簡易HTTPサーバー
+- `test/prompt-mapper.test.js` – Node.jsテスト
+- `SRS.md` – ソフトウェア要求仕様書
+- `LICENSE`
+
+## 開発
+
+1. Node.js 18 以降を用意します。
+2. リポジトリをクローンし依存をインストール: `npm install`
+3. テスト実行: `npm test`
+4. Webインターフェース起動: `npm start` → `http://localhost:3000` をブラウザで開く
+
+## ライセンス
+
+ISC

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "pochipochi-composer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "node --test",
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <title>PochiPochi Composer Demo</title>
+</head>
+<body>
+  <h1>PochiPochi Composer Demo</h1>
+
+  <section>
+    <h2>Tag Mapping</h2>
+    <input id="tags" value="ねこ, だいぼうけん" />
+    <button onclick="mapTags()">Map</button>
+    <pre id="map-result"></pre>
+  </section>
+
+  <section>
+    <h2>Mix Safety</h2>
+    <label>trebleGainDb <input id="treble" value="6" /></label>
+    <label>lowpassHz <input id="lowpass" value="20000" /></label>
+    <label>loudnessLUFS <input id="loudness" value="-10" /></label>
+    <button onclick="enforceMix()">Enforce</button>
+    <pre id="mix-result"></pre>
+  </section>
+
+  <section>
+    <h2>Quantize Melody</h2>
+    <textarea id="melody" rows="4" cols="40">{"ppq":480,"length":4,"notes":[{"pitch":61,"start":0,"duration":0.5}]}</textarea>
+    <label>Key <input id="key" value="C" /></label>
+    <label>Scale <input id="scale" value="major" /></label>
+    <button onclick="quantize()">Quantize</button>
+    <pre id="quantize-result"></pre>
+  </section>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/public/script.js
+++ b/public/script.js
@@ -1,0 +1,44 @@
+async function mapTags() {
+  const tags = document.getElementById('tags').value.split(',').map(t => t.trim()).filter(Boolean);
+  const res = await fetch('/api/map-tags', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ tags })
+  });
+  const json = await res.json();
+  document.getElementById('map-result').textContent = JSON.stringify(json, null, 2);
+}
+
+async function enforceMix() {
+  const data = {
+    trebleGainDb: parseFloat(document.getElementById('treble').value),
+    lowpassHz: parseFloat(document.getElementById('lowpass').value),
+    loudnessLUFS: parseFloat(document.getElementById('loudness').value)
+  };
+  const res = await fetch('/api/enforce-mix', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  const json = await res.json();
+  document.getElementById('mix-result').textContent = JSON.stringify(json, null, 2);
+}
+
+async function quantize() {
+  const melody = JSON.parse(document.getElementById('melody').value);
+  const key = document.getElementById('key').value;
+  const scale = document.getElementById('scale').value;
+  const res = await fetch('/api/quantize', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ melody, key, scale })
+  });
+  const json = await res.json();
+  document.getElementById('quantize-result').textContent = JSON.stringify(json, null, 2);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  mapTags();
+  enforceMix();
+  quantize();
+});

--- a/server.js
+++ b/server.js
@@ -1,0 +1,84 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+const { mapTagsToAttributes, enforceKidSafeMix, quantizeAndClamp } = require('./src/prompt-mapper');
+
+const publicDir = path.join(__dirname, 'public');
+
+function serveStatic(req, res) {
+  const filePath = path.join(publicDir, req.url === '/' ? 'index.html' : req.url);
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      res.end('Not found');
+      return;
+    }
+    const ext = path.extname(filePath);
+    const type = ext === '.js' ? 'text/javascript' : ext === '.html' ? 'text/html' : 'text/plain';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+}
+
+function parseBody(req, cb) {
+  let body = '';
+  req.on('data', (chunk) => (body += chunk));
+  req.on('end', () => {
+    try {
+      cb(null, JSON.parse(body || '{}'));
+    } catch (e) {
+      cb(e);
+    }
+  });
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET') {
+    return serveStatic(req, res);
+  }
+  if (req.method === 'POST' && req.url === '/api/map-tags') {
+    return parseBody(req, (err, data) => {
+      if (err) {
+        res.writeHead(400);
+        return res.end(JSON.stringify({ error: 'invalid json' }));
+      }
+      const result = mapTagsToAttributes(data.tags || []);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+    });
+  }
+  if (req.method === 'POST' && req.url === '/api/enforce-mix') {
+    return parseBody(req, (err, data) => {
+      if (err) {
+        res.writeHead(400);
+        return res.end(JSON.stringify({ error: 'invalid json' }));
+      }
+      const result = enforceKidSafeMix(data);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+    });
+  }
+  if (req.method === 'POST' && req.url === '/api/quantize') {
+    return parseBody(req, (err, data) => {
+      if (err) {
+        res.writeHead(400);
+        return res.end(JSON.stringify({ error: 'invalid json' }));
+      }
+      try {
+        const result = quantizeAndClamp(data.melody, data.key, data.scale);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+      } catch (e) {
+        res.writeHead(400);
+        res.end(JSON.stringify({ error: e.message }));
+      }
+    });
+  }
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`Server running at http://localhost:${port}`);
+});

--- a/src/prompt-mapper.js
+++ b/src/prompt-mapper.js
@@ -1,0 +1,89 @@
+const TAG_RULES = {
+  'ねこ': {
+    bpm: 112,
+    instruments: ['pizz_strings', 'marimba'],
+    drumPattern: 'brush',
+  },
+  'ねむい': {
+    bpm: 80,
+    drumPattern: 'none',
+    mix: { lowpassHz: 4000 },
+  },
+  'だいぼうけん': {
+    bpm: 140,
+    instruments: ['brass'],
+    drumPattern: 'snare',
+  },
+};
+
+function clampBpm(bpm) {
+  return Math.min(160, Math.max(80, bpm));
+}
+
+function mapTagsToAttributes(tags = [], tempo, key) {
+  const used = [];
+  let bpm = tempo ?? 112;
+  let instruments = [];
+  let drumPattern = 'basic';
+  let mix = { lowpassHz: 8000 };
+
+  const limited = tags.filter((t) => TAG_RULES[t]).slice(0, 3);
+  for (const t of limited) {
+    used.push(t);
+    const rule = TAG_RULES[t];
+    if (rule.instruments) instruments.push(...rule.instruments);
+    if (rule.drumPattern) drumPattern = rule.drumPattern;
+    if (rule.mix && rule.mix.lowpassHz) mix.lowpassHz = rule.mix.lowpassHz;
+  }
+
+  if (used.includes('ねむい') && used.includes('だいぼうけん')) {
+    bpm = 108;
+  } else if (used.length) {
+    for (const t of used) {
+      const rule = TAG_RULES[t];
+      if (rule.bpm !== undefined) bpm = rule.bpm;
+    }
+  }
+
+  bpm = clampBpm(bpm);
+  return { bpm, instruments, drumPattern, mix, usedTags: used };
+}
+
+function enforceKidSafeMix(mix) {
+  return {
+    trebleGainDb: Math.min(mix.trebleGainDb ?? 0, 0),
+    lowpassHz: Math.min(mix.lowpassHz ?? 20000, 8000),
+    loudnessLUFS: Math.max(mix.loudnessLUFS ?? -16, -16),
+  };
+}
+
+function quantizeAndClamp(melody, key, scale) {
+  const notes = melody.notes;
+  if (notes.length > 64) throw new Error('too many notes');
+  const allowed = buildScale(key, scale);
+  const quantized = notes.map((n) => ({ ...n, pitch: clampPitch(n.pitch, allowed) }));
+  return { ...melody, notes: quantized };
+}
+
+function buildScale(key, scale) {
+  const keyToMidi = { C: 60, D: 62, E: 64, F: 65, G: 67, A: 69, B: 71 };
+  const root = keyToMidi[key] ?? 60;
+  const intervals = scale === 'minor' ? [0, 2, 3, 5, 7, 8, 10] : [0, 2, 4, 5, 7, 9, 11];
+  return intervals.map((i) => root + i);
+}
+
+function clampPitch(pitch, allowed) {
+  if (allowed.includes(pitch)) return pitch;
+  let nearest = allowed[0];
+  let diff = Math.abs(pitch - nearest);
+  for (const a of allowed) {
+    const d = Math.abs(pitch - a);
+    if (d < diff) {
+      diff = d;
+      nearest = a;
+    }
+  }
+  return nearest;
+}
+
+module.exports = { mapTagsToAttributes, enforceKidSafeMix, quantizeAndClamp };

--- a/test/prompt-mapper.test.js
+++ b/test/prompt-mapper.test.js
@@ -1,0 +1,60 @@
+const test = require('node:test');
+const assert = require('assert');
+const { mapTagsToAttributes, enforceKidSafeMix, quantizeAndClamp } = require('../src/prompt-mapper');
+
+const Cmaj = { key: 'C', scale: 'major' };
+
+test('ねこ → 軽快、BPM=~112、ピッツィカート', () => {
+  const r = mapTagsToAttributes(['ねこ']);
+  assert.ok(r.bpm >= 104 && r.bpm <= 120);
+  assert.ok(r.instruments.includes('pizz_strings'));
+  assert.ok(/brush|light/.test(r.drumPattern));
+});
+
+test('ねむい → スロー、ドラム無し、ローパス', () => {
+  const r = mapTagsToAttributes(['ねむい']);
+  assert.ok(r.bpm <= 90);
+  assert.strictEqual(r.drumPattern, 'none');
+  assert.ok(r.mix.lowpassHz >= 2000);
+});
+
+test('だいぼうけん → 速め、ブラス/スネア強調', () => {
+  const r = mapTagsToAttributes(['だいぼうけん']);
+  assert.ok(r.bpm >= 124);
+  assert.ok(r.instruments.includes('brass'));
+  assert.ok(/snare|toms/.test(r.drumPattern));
+});
+
+test('競合解決: ねむい + だいぼうけん → 中庸BPM', () => {
+  const r = mapTagsToAttributes(['ねむい', 'だいぼうけん']);
+  assert.ok(r.bpm >= 96 && r.bpm <= 116);
+});
+
+test('未知タグは無視しつつ既知タグ適用', () => {
+  const r = mapTagsToAttributes(['???', 'ねこ']);
+  assert.ok(r.instruments.includes('pizz_strings'));
+});
+
+test('タグ>3は切り詰め', () => {
+  const r = mapTagsToAttributes(['ねこ', 'ねむい', 'だいぼうけん', 'さかな']);
+  assert.ok(r.usedTags.length <= 3);
+});
+
+test('高域ブースト過多を制限', () => {
+  const r = enforceKidSafeMix({ trebleGainDb: +6, lowpassHz: 20000, loudnessLUFS: -10 });
+  assert.ok(r.trebleGainDb <= 0);
+  assert.ok(r.loudnessLUFS >= -16);
+  assert.ok(r.lowpassHz <= 8000);
+});
+
+test('スケール外音を最近傍音へ吸着', () => {
+  const melody = { ppq: 480, length: 4, notes: [{ pitch: 61, start: 0, duration: 0.5 }] };
+  const r = quantizeAndClamp(melody, Cmaj.key, Cmaj.scale);
+  const allowed = [60, 62, 64, 65, 67, 69, 71];
+  assert.ok(allowed.includes(r.notes[0].pitch));
+});
+
+test('ノート数>64はエラー', () => {
+  const notes = Array.from({ length: 80 }, (_, i) => ({ pitch: 60, start: i * 0.25, duration: 0.25 }));
+  assert.throws(() => quantizeAndClamp({ ppq: 480, length: 8, notes }, 'C', 'major'));
+});


### PR DESCRIPTION
## Summary
- serve browser demo via minimal Node.js server
- expose tag mapping, mix safety and quantization through simple web UI
- document development setup and web demo usage (screenshot omitted to avoid binary file)

## Testing
- `npm test`
- `curl -s -X POST -H 'Content-Type: application/json' -d '{"tags":["ねこ","だいぼうけん"]}' http://localhost:3000/api/map-tags`


------
https://chatgpt.com/codex/tasks/task_e_689611400a98832aad166de9ecbdf699